### PR TITLE
fix(update-status-js): use UPDATE with affectedRows check instead of INSERT

### DIFF
--- a/actions/update-status-js/dist/index.js
+++ b/actions/update-status-js/dist/index.js
@@ -2,14 +2,14 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 2536:
+/***/ 1194:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const defaults_js_1 = __nccwpck_require__(7028);
-const proxies_js_1 = __nccwpck_require__(1128);
+const defaults_js_1 = __nccwpck_require__(9106);
+const proxies_js_1 = __nccwpck_require__(7542);
 const proxyBundle = {
     ca: proxies_js_1.proxies,
 };
@@ -23,7 +23,7 @@ module.exports["default"] = profiles;
 
 /***/ }),
 
-/***/ 7028:
+/***/ 9106:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2919,7 +2919,7 @@ exports.defaults = [
 
 /***/ }),
 
-/***/ 1128:
+/***/ 7542:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3038,7 +3038,7 @@ exports.proxies = [
 
 /***/ }),
 
-/***/ 6351:
+/***/ 2845:
 /***/ ((module) => {
 
 "use strict";
@@ -3527,11 +3527,11 @@ module.exports = Denque;
 
 /***/ }),
 
-/***/ 7263:
+/***/ 5005:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var util = __nccwpck_require__(9023)
-var isProperty = __nccwpck_require__(3941)
+var isProperty = __nccwpck_require__(1663)
 
 var INDENT_START = /[\{\[]/
 var INDENT_END = /[\}\]]/
@@ -3715,12 +3715,12 @@ module.exports = genfun
 
 /***/ }),
 
-/***/ 191:
+/***/ 2813:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // Multibyte codec. In this scheme, a character is represented by 1 or more bytes.
 // Our codec supports UTF-16 surrogates, extensions for GB18030 and unicode sequences.
@@ -4255,7 +4255,7 @@ function findIdx (table, val) {
 
 /***/ }),
 
-/***/ 4713:
+/***/ 2959:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4301,7 +4301,7 @@ module.exports = {
 
   shiftjis: {
     type: "_dbcs",
-    table: function () { return __nccwpck_require__(679) },
+    table: function () { return __nccwpck_require__(5446) },
     encodeAdd: { "\u00a5": 0x5C, "\u203E": 0x7E },
     encodeSkipVals: [{ from: 0xED40, to: 0xF940 }]
   },
@@ -4318,7 +4318,7 @@ module.exports = {
 
   eucjp: {
     type: "_dbcs",
-    table: function () { return __nccwpck_require__(6406) },
+    table: function () { return __nccwpck_require__(3789) },
     encodeAdd: { "\u00a5": 0x5C, "\u203E": 0x7E }
   },
 
@@ -4344,13 +4344,13 @@ module.exports = {
   936: "cp936",
   cp936: {
     type: "_dbcs",
-    table: function () { return __nccwpck_require__(4488) }
+    table: function () { return __nccwpck_require__(3719) }
   },
 
   // GBK (~22000 chars) is an extension of CP936 that added user-mapped chars and some other.
   gbk: {
     type: "_dbcs",
-    table: function () { return (__nccwpck_require__(4488).concat)(__nccwpck_require__(5914)) }
+    table: function () { return (__nccwpck_require__(3719).concat)(__nccwpck_require__(1981)) }
   },
   xgbk: "gbk",
   isoir58: "gbk",
@@ -4362,8 +4362,8 @@ module.exports = {
   // http://www.khngai.com/chinese/charmap/tblgbk.php?page=0
   gb18030: {
     type: "_dbcs",
-    table: function () { return (__nccwpck_require__(4488).concat)(__nccwpck_require__(5914)) },
-    gb18030: function () { return __nccwpck_require__(9129) },
+    table: function () { return (__nccwpck_require__(3719).concat)(__nccwpck_require__(1981)) },
+    gb18030: function () { return __nccwpck_require__(700) },
     encodeSkipVals: [0x80],
     encodeAdd: { "€": 0xA2E3 }
   },
@@ -4377,7 +4377,7 @@ module.exports = {
   949: "cp949",
   cp949: {
     type: "_dbcs",
-    table: function () { return __nccwpck_require__(1166) }
+    table: function () { return __nccwpck_require__(1525) }
   },
 
   cseuckr: "cp949",
@@ -4417,14 +4417,14 @@ module.exports = {
   950: "cp950",
   cp950: {
     type: "_dbcs",
-    table: function () { return __nccwpck_require__(2324) }
+    table: function () { return __nccwpck_require__(4567) }
   },
 
   // Big5 has many variations and is an extension of cp950. We use Encoding Standard's as a consensus.
   big5: "big5hkscs",
   big5hkscs: {
     type: "_dbcs",
-    table: function () { return (__nccwpck_require__(2324).concat)(__nccwpck_require__(3267)) },
+    table: function () { return (__nccwpck_require__(4567).concat)(__nccwpck_require__(2966)) },
     encodeSkipVals: [
       // Although Encoding Standard says we should avoid encoding to HKSCS area (See Step 1 of
       // https://encoding.spec.whatwg.org/#index-big5-pointer), we still do it to increase compatibility with ICU.
@@ -4448,26 +4448,26 @@ module.exports = {
 
 /***/ }),
 
-/***/ 5102:
+/***/ 2932:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var mergeModules = __nccwpck_require__(503)
+var mergeModules = __nccwpck_require__(2413)
 
 // Update this array if you add/rename/remove files in this directory.
 // We support Browserify by skipping automatic module discovery and requiring modules directly.
 var modules = [
-  __nccwpck_require__(2497),
-  __nccwpck_require__(7098),
-  __nccwpck_require__(244),
-  __nccwpck_require__(8246),
-  __nccwpck_require__(2068),
-  __nccwpck_require__(6724),
-  __nccwpck_require__(5100),
-  __nccwpck_require__(191),
-  __nccwpck_require__(4713)
+  __nccwpck_require__(5475),
+  __nccwpck_require__(640),
+  __nccwpck_require__(5886),
+  __nccwpck_require__(2260),
+  __nccwpck_require__(6566),
+  __nccwpck_require__(1830),
+  __nccwpck_require__(5874),
+  __nccwpck_require__(2813),
+  __nccwpck_require__(2959)
 ]
 
 // Put all encoding/alias/codec definitions to single object and export it.
@@ -4479,12 +4479,12 @@ for (var i = 0; i < modules.length; i++) {
 
 /***/ }),
 
-/***/ 2497:
+/***/ 5475:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // Export Node.js internal encodings.
 
@@ -4705,12 +4705,12 @@ InternalEncoderUtf8.prototype.end = function () {
 
 /***/ }),
 
-/***/ 2068:
+/***/ 6566:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // Single-byte codec. Needs a 'chars' string parameter that contains 256 or 128 chars that
 // correspond to encoded bytes (if 128 - then lower half is ASCII).
@@ -4788,7 +4788,7 @@ SBCSDecoder.prototype.end = function () {
 
 /***/ }),
 
-/***/ 5100:
+/***/ 5874:
 /***/ ((module) => {
 
 "use strict";
@@ -5246,7 +5246,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6724:
+/***/ 1830:
 /***/ ((module) => {
 
 "use strict";
@@ -5432,12 +5432,12 @@ module.exports = {
 
 /***/ }),
 
-/***/ 244:
+/***/ 5886:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // Note: UTF16-LE (or UCS2) codec is Node.js native. See encodings/internal.js
 
@@ -5627,13 +5627,13 @@ function detectEncoding (bufs, defaultEncoding) {
 
 /***/ }),
 
-/***/ 7098:
+/***/ 640:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // == UTF32-LE/BE codec. ==========================================================
 
@@ -5942,12 +5942,12 @@ function detectEncoding (bufs, defaultEncoding) {
 
 /***/ }),
 
-/***/ 8246:
+/***/ 2260:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // UTF-7 codec, according to https://tools.ietf.org/html/rfc2152
 // See also below a UTF-7-IMAP codec, according to http://tools.ietf.org/html/rfc3501#section-5.1.3
@@ -6233,7 +6233,7 @@ Utf7IMAPDecoder.prototype.end = function () {
 
 /***/ }),
 
-/***/ 5251:
+/***/ 5201:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -6289,7 +6289,7 @@ StripBOMWrapper.prototype.end = function () {
 
 /***/ }),
 
-/***/ 503:
+/***/ 2413:
 /***/ ((module) => {
 
 "use strict";
@@ -6310,16 +6310,16 @@ module.exports = mergeModules
 
 /***/ }),
 
-/***/ 2211:
+/***/ 9093:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
-var bomHandling = __nccwpck_require__(5251)
-var mergeModules = __nccwpck_require__(503)
+var bomHandling = __nccwpck_require__(5201)
+var mergeModules = __nccwpck_require__(2413)
 
 // All codecs and aliases are kept here, keyed by encoding name/alias.
 // They are lazy loaded in `iconv.getCodec` from `encodings/index.js`.
@@ -6378,7 +6378,7 @@ module.exports._codecDataCache = { __proto__: null }
 
 module.exports.getCodec = function getCodec (encoding) {
   if (!module.exports.encodings) {
-    var raw = __nccwpck_require__(5102)
+    var raw = __nccwpck_require__(2932)
     // TODO: In future versions when old nodejs support is removed can use object.assign
     module.exports.encodings = { __proto__: null } // Initialize as empty object.
     mergeModules(module.exports.encodings, raw)
@@ -6458,7 +6458,7 @@ module.exports.enableStreamingAPI = function enableStreamingAPI (streamModule) {
   if (module.exports.supportsStreams) { return }
 
   // Dependency-inject stream module to create IconvLite stream classes.
-  var streams = __nccwpck_require__(6818)(streamModule)
+  var streams = __nccwpck_require__(7748)(streamModule)
 
   // Not public API yet, but expose the stream classes.
   module.exports.IconvLiteEncoderStream = streams.IconvLiteEncoderStream
@@ -6498,13 +6498,13 @@ if (false) {}
 
 /***/ }),
 
-/***/ 6818:
+/***/ 7748:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Buffer = (__nccwpck_require__(6508).Buffer)
+var Buffer = (__nccwpck_require__(6978).Buffer)
 
 // NOTE: Due to 'stream' module being pretty large (~100Kb, significant in browser environments),
 // we opt to dependency-inject it instead of creating a hard dependency.
@@ -6611,7 +6611,7 @@ module.exports = function (streamModule) {
 
 /***/ }),
 
-/***/ 3941:
+/***/ 1663:
 /***/ ((module) => {
 
 "use strict";
@@ -6623,15 +6623,15 @@ module.exports = isProperty
 
 /***/ }),
 
-/***/ 5080:
+/***/ 150:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 
-var loader = __nccwpck_require__(2169);
-var dumper = __nccwpck_require__(1111);
+var loader = __nccwpck_require__(1671);
+var dumper = __nccwpck_require__(8889);
 
 
 function renamed(from, to) {
@@ -6642,32 +6642,32 @@ function renamed(from, to) {
 }
 
 
-module.exports.Type = __nccwpck_require__(1666);
-module.exports.Schema = __nccwpck_require__(4789);
-module.exports.FAILSAFE_SCHEMA = __nccwpck_require__(4297);
-module.exports.JSON_SCHEMA = __nccwpck_require__(9398);
-module.exports.CORE_SCHEMA = __nccwpck_require__(2419);
-module.exports.DEFAULT_SCHEMA = __nccwpck_require__(4999);
+module.exports.Type = __nccwpck_require__(2696);
+module.exports.Schema = __nccwpck_require__(5459);
+module.exports.FAILSAFE_SCHEMA = __nccwpck_require__(7115);
+module.exports.JSON_SCHEMA = __nccwpck_require__(4884);
+module.exports.CORE_SCHEMA = __nccwpck_require__(7061);
+module.exports.DEFAULT_SCHEMA = __nccwpck_require__(1989);
 module.exports.load                = loader.load;
 module.exports.loadAll             = loader.loadAll;
 module.exports.dump                = dumper.dump;
-module.exports.YAMLException = __nccwpck_require__(2965);
+module.exports.YAMLException = __nccwpck_require__(9035);
 
 // Re-export all types in case user wants to create custom schema
 module.exports.types = {
-  binary:    __nccwpck_require__(8000),
-  float:     __nccwpck_require__(4871),
-  map:       __nccwpck_require__(5891),
-  null:      __nccwpck_require__(4808),
-  pairs:     __nccwpck_require__(6400),
-  set:       __nccwpck_require__(8989),
-  timestamp: __nccwpck_require__(8125),
-  bool:      __nccwpck_require__(7361),
-  int:       __nccwpck_require__(3368),
-  merge:     __nccwpck_require__(9493),
-  omap:      __nccwpck_require__(7908),
-  seq:       __nccwpck_require__(3346),
-  str:       __nccwpck_require__(7254)
+  binary:    __nccwpck_require__(3250),
+  float:     __nccwpck_require__(3849),
+  map:       __nccwpck_require__(3165),
+  null:      __nccwpck_require__(7290),
+  pairs:     __nccwpck_require__(2722),
+  set:       __nccwpck_require__(1915),
+  timestamp: __nccwpck_require__(2347),
+  bool:      __nccwpck_require__(8827),
+  int:       __nccwpck_require__(2550),
+  merge:     __nccwpck_require__(207),
+  omap:      __nccwpck_require__(5870),
+  seq:       __nccwpck_require__(9768),
+  str:       __nccwpck_require__(7592)
 };
 
 // Removed functions from JS-YAML 3.0.x
@@ -6678,7 +6678,7 @@ module.exports.safeDump            = renamed('safeDump', 'dump');
 
 /***/ }),
 
-/***/ 5279:
+/***/ 2181:
 /***/ ((module) => {
 
 "use strict";
@@ -6745,7 +6745,7 @@ module.exports.extend         = extend;
 
 /***/ }),
 
-/***/ 1111:
+/***/ 8889:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -6753,9 +6753,9 @@ module.exports.extend         = extend;
 
 /*eslint-disable no-use-before-define*/
 
-var common              = __nccwpck_require__(5279);
-var YAMLException       = __nccwpck_require__(2965);
-var DEFAULT_SCHEMA      = __nccwpck_require__(4999);
+var common              = __nccwpck_require__(2181);
+var YAMLException       = __nccwpck_require__(9035);
+var DEFAULT_SCHEMA      = __nccwpck_require__(1989);
 
 var _toString       = Object.prototype.toString;
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -7718,7 +7718,7 @@ module.exports.dump = dump;
 
 /***/ }),
 
-/***/ 2965:
+/***/ 9035:
 /***/ ((module) => {
 
 "use strict";
@@ -7781,7 +7781,7 @@ module.exports = YAMLException;
 
 /***/ }),
 
-/***/ 2169:
+/***/ 1671:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7789,10 +7789,10 @@ module.exports = YAMLException;
 
 /*eslint-disable max-len,no-use-before-define*/
 
-var common              = __nccwpck_require__(5279);
-var YAMLException       = __nccwpck_require__(2965);
-var makeSnippet         = __nccwpck_require__(4029);
-var DEFAULT_SCHEMA      = __nccwpck_require__(4999);
+var common              = __nccwpck_require__(2181);
+var YAMLException       = __nccwpck_require__(9035);
+var makeSnippet         = __nccwpck_require__(3375);
+var DEFAULT_SCHEMA      = __nccwpck_require__(1989);
 
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -9522,7 +9522,7 @@ module.exports.load    = load;
 
 /***/ }),
 
-/***/ 4789:
+/***/ 5459:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9530,8 +9530,8 @@ module.exports.load    = load;
 
 /*eslint-disable max-len*/
 
-var YAMLException = __nccwpck_require__(2965);
-var Type          = __nccwpck_require__(1666);
+var YAMLException = __nccwpck_require__(9035);
+var Type          = __nccwpck_require__(2696);
 
 
 function compileList(schema, name) {
@@ -9651,7 +9651,7 @@ module.exports = Schema;
 
 /***/ }),
 
-/***/ 2419:
+/***/ 7061:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9665,12 +9665,12 @@ module.exports = Schema;
 
 
 
-module.exports = __nccwpck_require__(9398);
+module.exports = __nccwpck_require__(4884);
 
 
 /***/ }),
 
-/***/ 4999:
+/***/ 1989:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9684,23 +9684,23 @@ module.exports = __nccwpck_require__(9398);
 
 
 
-module.exports = (__nccwpck_require__(2419).extend)({
+module.exports = (__nccwpck_require__(7061).extend)({
   implicit: [
-    __nccwpck_require__(8125),
-    __nccwpck_require__(9493)
+    __nccwpck_require__(2347),
+    __nccwpck_require__(207)
   ],
   explicit: [
-    __nccwpck_require__(8000),
-    __nccwpck_require__(7908),
-    __nccwpck_require__(6400),
-    __nccwpck_require__(8989)
+    __nccwpck_require__(3250),
+    __nccwpck_require__(5870),
+    __nccwpck_require__(2722),
+    __nccwpck_require__(1915)
   ]
 });
 
 
 /***/ }),
 
-/***/ 4297:
+/***/ 7115:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9711,21 +9711,21 @@ module.exports = (__nccwpck_require__(2419).extend)({
 
 
 
-var Schema = __nccwpck_require__(4789);
+var Schema = __nccwpck_require__(5459);
 
 
 module.exports = new Schema({
   explicit: [
-    __nccwpck_require__(7254),
-    __nccwpck_require__(3346),
-    __nccwpck_require__(5891)
+    __nccwpck_require__(7592),
+    __nccwpck_require__(9768),
+    __nccwpck_require__(3165)
   ]
 });
 
 
 /***/ }),
 
-/***/ 9398:
+/***/ 4884:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9740,26 +9740,26 @@ module.exports = new Schema({
 
 
 
-module.exports = (__nccwpck_require__(4297).extend)({
+module.exports = (__nccwpck_require__(7115).extend)({
   implicit: [
-    __nccwpck_require__(4808),
-    __nccwpck_require__(7361),
-    __nccwpck_require__(3368),
-    __nccwpck_require__(4871)
+    __nccwpck_require__(7290),
+    __nccwpck_require__(8827),
+    __nccwpck_require__(2550),
+    __nccwpck_require__(3849)
   ]
 });
 
 
 /***/ }),
 
-/***/ 4029:
+/***/ 3375:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 
-var common = __nccwpck_require__(5279);
+var common = __nccwpck_require__(2181);
 
 
 // get snippet for a single line, respecting maxLength
@@ -9861,13 +9861,13 @@ module.exports = makeSnippet;
 
 /***/ }),
 
-/***/ 1666:
+/***/ 2696:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var YAMLException = __nccwpck_require__(2965);
+var YAMLException = __nccwpck_require__(9035);
 
 var TYPE_CONSTRUCTOR_OPTIONS = [
   'kind',
@@ -9935,7 +9935,7 @@ module.exports = Type;
 
 /***/ }),
 
-/***/ 8000:
+/***/ 3250:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -9944,7 +9944,7 @@ module.exports = Type;
 /*eslint-disable no-bitwise*/
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 
 // [ 64, 65, 66 ] -> [ padding, CR, LF ]
@@ -10068,13 +10068,13 @@ module.exports = new Type('tag:yaml.org,2002:binary', {
 
 /***/ }),
 
-/***/ 7361:
+/***/ 8827:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 function resolveYamlBoolean(data) {
   if (data === null) return false;
@@ -10111,14 +10111,14 @@ module.exports = new Type('tag:yaml.org,2002:bool', {
 
 /***/ }),
 
-/***/ 4871:
+/***/ 3849:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var common = __nccwpck_require__(5279);
-var Type   = __nccwpck_require__(1666);
+var common = __nccwpck_require__(2181);
+var Type   = __nccwpck_require__(2696);
 
 var YAML_FLOAT_PATTERN = new RegExp(
   // 2.5e4, 2.5 and integers
@@ -10216,14 +10216,14 @@ module.exports = new Type('tag:yaml.org,2002:float', {
 
 /***/ }),
 
-/***/ 3368:
+/***/ 2550:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var common = __nccwpck_require__(5279);
-var Type   = __nccwpck_require__(1666);
+var common = __nccwpck_require__(2181);
+var Type   = __nccwpck_require__(2696);
 
 function isHexCode(c) {
   return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) ||
@@ -10380,13 +10380,13 @@ module.exports = new Type('tag:yaml.org,2002:int', {
 
 /***/ }),
 
-/***/ 5891:
+/***/ 3165:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 module.exports = new Type('tag:yaml.org,2002:map', {
   kind: 'mapping',
@@ -10396,13 +10396,13 @@ module.exports = new Type('tag:yaml.org,2002:map', {
 
 /***/ }),
 
-/***/ 9493:
+/***/ 207:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 function resolveYamlMerge(data) {
   return data === '<<' || data === null;
@@ -10416,13 +10416,13 @@ module.exports = new Type('tag:yaml.org,2002:merge', {
 
 /***/ }),
 
-/***/ 4808:
+/***/ 7290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 function resolveYamlNull(data) {
   if (data === null) return true;
@@ -10459,13 +10459,13 @@ module.exports = new Type('tag:yaml.org,2002:null', {
 
 /***/ }),
 
-/***/ 7908:
+/***/ 5870:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
 var _toString       = Object.prototype.toString;
@@ -10511,13 +10511,13 @@ module.exports = new Type('tag:yaml.org,2002:omap', {
 
 /***/ }),
 
-/***/ 6400:
+/***/ 2722:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 var _toString = Object.prototype.toString;
 
@@ -10572,13 +10572,13 @@ module.exports = new Type('tag:yaml.org,2002:pairs', {
 
 /***/ }),
 
-/***/ 3346:
+/***/ 9768:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 module.exports = new Type('tag:yaml.org,2002:seq', {
   kind: 'sequence',
@@ -10588,13 +10588,13 @@ module.exports = new Type('tag:yaml.org,2002:seq', {
 
 /***/ }),
 
-/***/ 8989:
+/***/ 1915:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 var _hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -10625,13 +10625,13 @@ module.exports = new Type('tag:yaml.org,2002:set', {
 
 /***/ }),
 
-/***/ 7254:
+/***/ 7592:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 module.exports = new Type('tag:yaml.org,2002:str', {
   kind: 'scalar',
@@ -10641,13 +10641,13 @@ module.exports = new Type('tag:yaml.org,2002:str', {
 
 /***/ }),
 
-/***/ 8125:
+/***/ 2347:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var Type = __nccwpck_require__(1666);
+var Type = __nccwpck_require__(2696);
 
 var YAML_DATE_REGEXP = new RegExp(
   '^([0-9][0-9][0-9][0-9])'          + // [1] year
@@ -10737,7 +10737,7 @@ module.exports = new Type('tag:yaml.org,2002:timestamp', {
 
 /***/ }),
 
-/***/ 3806:
+/***/ 4648:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -10993,7 +10993,7 @@ exports.createLRU = createLRU;
 
 /***/ }),
 
-/***/ 8705:
+/***/ 7695:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11077,7 +11077,7 @@ function createCompiler(config) {
     cache = config.cache;
   }
   if (config.cache !== false && !cache) {
-    cache = (__nccwpck_require__(3806).createLRU)({ max: ncache });
+    cache = (__nccwpck_require__(4648).createLRU)({ max: ncache });
   }
 
   function toArrayParams(tree, params) {
@@ -11180,7 +11180,7 @@ module.exports.toNumbered = toNumbered;
 
 /***/ }),
 
-/***/ 6508:
+/***/ 6978:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11265,7 +11265,7 @@ module.exports = safer
 
 /***/ }),
 
-/***/ 3255:
+/***/ 9301:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -11671,7 +11671,7 @@ exports.raw = raw;
 
 /***/ }),
 
-/***/ 4158:
+/***/ 8941:
 /***/ ((module) => {
 
 module.exports = eval("require")("cardinal");
@@ -11783,7 +11783,7 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 5957:
+/***/ 1519:
 /***/ (function(module, exports) {
 
 // GENERATED FILE. DO NOT EDIT.
@@ -13406,7 +13406,7 @@ module.exports = require("zlib");
 
 /***/ }),
 
-/***/ 3378:
+/***/ 1420:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13509,7 +13509,7 @@ exports.xorRotating = xorRotating;
 
 /***/ }),
 
-/***/ 876:
+/***/ 7454:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13519,7 +13519,7 @@ exports.xorRotating = xorRotating;
 
 const PLUGIN_NAME = 'caching_sha2_password';
 const crypto = __nccwpck_require__(6982);
-const { xor, xorRotating } = __nccwpck_require__(3378);
+const { xor, xorRotating } = __nccwpck_require__(1420);
 
 const REQUEST_SERVER_KEY_PACKET = Buffer.from([2]);
 const FAST_AUTH_SUCCESS_PACKET = Buffer.from([3]);
@@ -13625,7 +13625,7 @@ module.exports =
 
 /***/ }),
 
-/***/ 6256:
+/***/ 7954:
 /***/ ((module) => {
 
 "use strict";
@@ -13650,14 +13650,14 @@ module.exports = create_mysql_clear_password_plugin;
 
 /***/ }),
 
-/***/ 6214:
+/***/ 9972:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 //const PLUGIN_NAME = 'mysql_native_password';
-const auth41 = __nccwpck_require__(3378);
+const auth41 = __nccwpck_require__(1420);
 
 module.exports =
   (pluginOptions) =>
@@ -13692,7 +13692,7 @@ module.exports =
 
 /***/ }),
 
-/***/ 4535:
+/***/ 1609:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13700,7 +13700,7 @@ module.exports =
 
 const PLUGIN_NAME = 'sha256_password';
 const crypto = __nccwpck_require__(6982);
-const { xorRotating } = __nccwpck_require__(3378);
+const { xorRotating } = __nccwpck_require__(1420);
 const Tls = __nccwpck_require__(4756);
 
 const REQUEST_SERVER_KEY_PACKET = Buffer.from([1]);
@@ -13768,7 +13768,7 @@ module.exports =
 
 /***/ }),
 
-/***/ 2308:
+/***/ 4786:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -13794,14 +13794,14 @@ const Tls = __nccwpck_require__(4756);
 const Timers = __nccwpck_require__(3557);
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
 const Readable = (__nccwpck_require__(2203).Readable);
-const Queue = __nccwpck_require__(6351);
-const SqlString = __nccwpck_require__(3255);
-const { createLRU } = __nccwpck_require__(3806);
-const PacketParser = __nccwpck_require__(7552);
-const Packets = __nccwpck_require__(6784);
-const Commands = __nccwpck_require__(5981);
-const ConnectionConfig = __nccwpck_require__(5009);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const Queue = __nccwpck_require__(2845);
+const SqlString = __nccwpck_require__(9301);
+const { createLRU } = __nccwpck_require__(4648);
+const PacketParser = __nccwpck_require__(7062);
+const Packets = __nccwpck_require__(5906);
+const Commands = __nccwpck_require__(6983);
+const ConnectionConfig = __nccwpck_require__(1931);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 let _connectionId = 0;
 
@@ -14354,7 +14354,7 @@ class BaseConnection extends EventEmitter {
         return;
       }
       if (convertNamedPlaceholders === null) {
-        convertNamedPlaceholders = __nccwpck_require__(8705)();
+        convertNamedPlaceholders = __nccwpck_require__(7695)();
       }
       unnamed = convertNamedPlaceholders(options.sql, options.values);
       options.sql = unnamed[0];
@@ -14754,19 +14754,19 @@ module.exports = BaseConnection;
 
 /***/ }),
 
-/***/ 4854:
+/***/ 5400:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const process = __nccwpck_require__(932);
-const SqlString = __nccwpck_require__(3255);
+const SqlString = __nccwpck_require__(9301);
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
-const PoolConnection = __nccwpck_require__(757);
-const Queue = __nccwpck_require__(6351);
-const BaseConnection = __nccwpck_require__(2308);
-const Errors = __nccwpck_require__(7129);
+const PoolConnection = __nccwpck_require__(7323);
+const Queue = __nccwpck_require__(2845);
+const BaseConnection = __nccwpck_require__(4786);
+const Errors = __nccwpck_require__(2067);
 
 // Source: https://github.com/go-sql-driver/mysql/blob/76c00e35a8d48f8f70f0e7dffe584692bd3fa612/packets.go#L598-L613
 function isReadOnlyError(err) {
@@ -15038,13 +15038,13 @@ module.exports = BasePool;
 
 /***/ }),
 
-/***/ 4053:
+/***/ 4963:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const BaseConnection = __nccwpck_require__(2308);
+const BaseConnection = __nccwpck_require__(4786);
 
 class BasePoolConnection extends BaseConnection {
   constructor(pool, options) {
@@ -15119,7 +15119,7 @@ BasePoolConnection.prototype._realEnd = BaseConnection.prototype.end;
 
 /***/ }),
 
-/***/ 1046:
+/***/ 5340:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15130,11 +15130,11 @@ BasePoolConnection.prototype._realEnd = BaseConnection.prototype.end;
 
 
 
-const Packets = __nccwpck_require__(6784);
-const sha256_password = __nccwpck_require__(4535);
-const caching_sha2_password = __nccwpck_require__(876);
-const mysql_native_password = __nccwpck_require__(6214);
-const mysql_clear_password = __nccwpck_require__(6256);
+const Packets = __nccwpck_require__(5906);
+const sha256_password = __nccwpck_require__(1609);
+const caching_sha2_password = __nccwpck_require__(7454);
+const mysql_native_password = __nccwpck_require__(9972);
+const mysql_clear_password = __nccwpck_require__(7954);
 
 const standardAuthPlugins = {
   sha256_password: sha256_password({}),
@@ -15238,14 +15238,14 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7421:
+/***/ 3847:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
 
 const eventParsers = [];
 
@@ -15322,7 +15322,7 @@ class FormatDescriptionEvent {
 
 class QueryEvent {
   constructor(packet) {
-    const parseStatusVars = __nccwpck_require__(7755);
+    const parseStatusVars = __nccwpck_require__(6625);
     this.slaveProxyId = packet.readInt32();
     this.executionTime = packet.readInt32();
     const schemaLength = packet.readInt8();
@@ -15355,7 +15355,7 @@ module.exports = BinlogDump;
 
 /***/ }),
 
-/***/ 8547:
+/***/ 201:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15367,11 +15367,11 @@ module.exports = BinlogDump;
 
 
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
-const ClientConstants = __nccwpck_require__(9441);
-const ClientHandshake = __nccwpck_require__(3324);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
+const ClientConstants = __nccwpck_require__(551);
+const ClientHandshake = __nccwpck_require__(846);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 class ChangeUser extends Command {
   constructor(options, callback) {
@@ -15431,7 +15431,7 @@ module.exports = ChangeUser;
 
 /***/ }),
 
-/***/ 3324:
+/***/ 846:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15447,11 +15447,11 @@ module.exports = ChangeUser;
 
 
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
-const ClientConstants = __nccwpck_require__(9441);
-const CharsetToEncoding = __nccwpck_require__(9713);
-const auth41 = __nccwpck_require__(3378);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
+const ClientConstants = __nccwpck_require__(551);
+const CharsetToEncoding = __nccwpck_require__(7035);
+const auth41 = __nccwpck_require__(1420);
 
 function flagNames(flags) {
   const res = [];
@@ -15610,7 +15610,7 @@ class ClientHandshake extends Command {
     // packet can be OK_Packet, ERR_Packet, AuthSwitchRequest, AuthNextFactor
     // or AuthMoreData
     if (marker === 0xfe || marker === 1 || marker === 0x02) {
-      const authSwitch = __nccwpck_require__(1046);
+      const authSwitch = __nccwpck_require__(5340);
       try {
         if (marker === 1) {
           authSwitch.authSwitchRequestMoreData(packet, connection, this);
@@ -15663,7 +15663,7 @@ class ClientHandshake extends Command {
       connection.authorized = true;
       if (connection.config.compress) {
         const enableCompression =
-          (__nccwpck_require__(5176).enableCompression);
+          (__nccwpck_require__(3826).enableCompression);
         enableCompression(connection);
       }
     }
@@ -15678,14 +15678,14 @@ module.exports = ClientHandshake;
 
 /***/ }),
 
-/***/ 9731:
+/***/ 2361:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
 
 class CloseStatement extends Command {
   constructor(id) {
@@ -15704,7 +15704,7 @@ module.exports = CloseStatement;
 
 /***/ }),
 
-/***/ 9108:
+/***/ 1046:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15766,18 +15766,18 @@ module.exports = Command;
 
 /***/ }),
 
-/***/ 1446:
+/***/ 2240:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const Query = __nccwpck_require__(773);
-const Packets = __nccwpck_require__(6784);
+const Command = __nccwpck_require__(1046);
+const Query = __nccwpck_require__(3759);
+const Packets = __nccwpck_require__(5906);
 
-const getBinaryParser = __nccwpck_require__(2448);
-const getStaticBinaryParser = __nccwpck_require__(9457);
+const getBinaryParser = __nccwpck_require__(8166);
+const getStaticBinaryParser = __nccwpck_require__(4687);
 
 class Execute extends Command {
   constructor(options, callback) {
@@ -15886,23 +15886,23 @@ module.exports = Execute;
 
 /***/ }),
 
-/***/ 5981:
+/***/ 6983:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const ClientHandshake = __nccwpck_require__(3324);
-const ServerHandshake = __nccwpck_require__(6392);
-const Query = __nccwpck_require__(773);
-const Prepare = __nccwpck_require__(7054);
-const CloseStatement = __nccwpck_require__(9731);
-const Execute = __nccwpck_require__(1446);
-const Ping = __nccwpck_require__(7977);
-const RegisterSlave = __nccwpck_require__(1080);
-const BinlogDump = __nccwpck_require__(7421);
-const ChangeUser = __nccwpck_require__(8547);
-const Quit = __nccwpck_require__(8606);
+const ClientHandshake = __nccwpck_require__(846);
+const ServerHandshake = __nccwpck_require__(162);
+const Query = __nccwpck_require__(3759);
+const Prepare = __nccwpck_require__(1500);
+const CloseStatement = __nccwpck_require__(2361);
+const Execute = __nccwpck_require__(2240);
+const Ping = __nccwpck_require__(9579);
+const RegisterSlave = __nccwpck_require__(7942);
+const BinlogDump = __nccwpck_require__(3847);
+const ChangeUser = __nccwpck_require__(201);
+const Quit = __nccwpck_require__(2480);
 
 module.exports = {
   ClientHandshake,
@@ -15921,15 +15921,15 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7977:
+/***/ 9579:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const CommandCode = __nccwpck_require__(8648);
-const Packet = __nccwpck_require__(2410);
+const Command = __nccwpck_require__(1046);
+const CommandCode = __nccwpck_require__(1438);
+const Packet = __nccwpck_require__(3164);
 
 // TODO: time statistics?
 // usefull for queue size and network latency monitoring
@@ -15965,16 +15965,16 @@ module.exports = Ping;
 
 /***/ }),
 
-/***/ 7054:
+/***/ 1500:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packets = __nccwpck_require__(6784);
-const Command = __nccwpck_require__(9108);
-const CloseStatement = __nccwpck_require__(9731);
-const Execute = __nccwpck_require__(1446);
+const Packets = __nccwpck_require__(5906);
+const Command = __nccwpck_require__(1046);
+const CloseStatement = __nccwpck_require__(2361);
+const Execute = __nccwpck_require__(2240);
 
 class PreparedStatementInfo {
   constructor(query, id, columns, parameters, connection) {
@@ -16116,7 +16116,7 @@ module.exports = Prepare;
 
 /***/ }),
 
-/***/ 773:
+/***/ 3759:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16127,11 +16127,11 @@ const Timers = __nccwpck_require__(3557);
 
 const Readable = (__nccwpck_require__(2203).Readable);
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
-const getTextParser = __nccwpck_require__(5406);
-const staticParser = __nccwpck_require__(1683);
-const ServerStatus = __nccwpck_require__(898);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
+const getTextParser = __nccwpck_require__(3664);
+const staticParser = __nccwpck_require__(8581);
+const ServerStatus = __nccwpck_require__(8496);
 
 const EmptyPacket = new Packets.Packet(0, Buffer.allocUnsafe(4), 0, 4);
 
@@ -16485,15 +16485,15 @@ module.exports = Query;
 
 /***/ }),
 
-/***/ 8606:
+/***/ 2480:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const CommandCode = __nccwpck_require__(8648);
-const Packet = __nccwpck_require__(2410);
+const Command = __nccwpck_require__(1046);
+const CommandCode = __nccwpck_require__(1438);
+const Packet = __nccwpck_require__(3164);
 
 class Quit extends Command {
   constructor(callback) {
@@ -16522,14 +16522,14 @@ module.exports = Quit;
 
 /***/ }),
 
-/***/ 1080:
+/***/ 7942:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
 
 class RegisterSlave extends Command {
   constructor(opts, callback) {
@@ -16557,17 +16557,17 @@ module.exports = RegisterSlave;
 
 /***/ }),
 
-/***/ 6392:
+/***/ 162:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const CommandCode = __nccwpck_require__(8648);
-const Errors = __nccwpck_require__(7129);
+const CommandCode = __nccwpck_require__(1438);
+const Errors = __nccwpck_require__(2067);
 
-const Command = __nccwpck_require__(9108);
-const Packets = __nccwpck_require__(6784);
+const Command = __nccwpck_require__(1046);
+const Packets = __nccwpck_require__(5906);
 
 class ServerHandshake extends Command {
   constructor(args) {
@@ -16767,7 +16767,7 @@ server stores sha1(sha1(password)) ( hash_stag2)
 
 /***/ }),
 
-/***/ 5176:
+/***/ 3826:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16777,7 +16777,7 @@ server stores sha1(sha1(password)) ( hash_stag2)
 // implementation of http://dev.mysql.com/doc/internals/en/compression.html
 
 const zlib = __nccwpck_require__(3106);
-const PacketParser = __nccwpck_require__(7552);
+const PacketParser = __nccwpck_require__(7062);
 
 class Queue {
   constructor() {
@@ -16928,17 +16928,17 @@ module.exports = {
 
 /***/ }),
 
-/***/ 3604:
+/***/ 250:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const BaseConnection = __nccwpck_require__(2308);
+const BaseConnection = __nccwpck_require__(4786);
 
 class Connection extends BaseConnection {
   promise(promiseImpl) {
-    const PromiseConnection = __nccwpck_require__(3974);
+    const PromiseConnection = __nccwpck_require__(2628);
     return new PromiseConnection(this, promiseImpl);
   }
 }
@@ -16948,7 +16948,7 @@ module.exports = Connection;
 
 /***/ }),
 
-/***/ 5009:
+/***/ 1931:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16962,9 +16962,9 @@ module.exports = Connection;
 
 
 const { URL } = __nccwpck_require__(7016);
-const ClientConstants = __nccwpck_require__(9441);
-const Charsets = __nccwpck_require__(4399);
-const { version } = __nccwpck_require__(7466);
+const ClientConstants = __nccwpck_require__(551);
+const Charsets = __nccwpck_require__(6565);
+const { version } = __nccwpck_require__(9231);
 let SSLProfiles = null;
 
 const validOptions = {
@@ -17213,7 +17213,7 @@ class ConnectionConfig {
 
   static getSSLProfile(name) {
     if (!SSLProfiles) {
-      SSLProfiles = __nccwpck_require__(1823);
+      SSLProfiles = __nccwpck_require__(7729);
     }
     const ssl = SSLProfiles[name];
     if (ssl === undefined) {
@@ -17249,7 +17249,7 @@ module.exports = ConnectionConfig;
 
 /***/ }),
 
-/***/ 9713:
+/***/ 7035:
 /***/ ((module) => {
 
 "use strict";
@@ -17573,7 +17573,7 @@ module.exports = [
 
 /***/ }),
 
-/***/ 4399:
+/***/ 6565:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -17898,7 +17898,7 @@ exports.GEOSTD8 = exports.GEOSTD8_GENERAL_CI;
 
 /***/ }),
 
-/***/ 9441:
+/***/ 551:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -17944,7 +17944,7 @@ exports.MULTI_FACTOR_AUTHENTICATION = 0x10000000; /* multi-factor authentication
 
 /***/ }),
 
-/***/ 8648:
+/***/ 1438:
 /***/ ((module) => {
 
 "use strict";
@@ -17988,7 +17988,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6196:
+/***/ 7990:
 /***/ ((module) => {
 
 "use strict";
@@ -18004,7 +18004,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9112:
+/***/ 482:
 /***/ ((module) => {
 
 "use strict";
@@ -18062,7 +18062,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 7129:
+/***/ 2067:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22043,7 +22043,7 @@ exports[4162] = 'ER_WARN_DEPRECATED_USER_DEFINED_COLLATIONS';
 
 /***/ }),
 
-/***/ 4720:
+/***/ 2342:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22071,7 +22071,7 @@ exports.NUM = 32768; /* Field is num (for clients) */
 
 /***/ }),
 
-/***/ 898:
+/***/ 8496:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22123,7 +22123,7 @@ exports.SERVER_SESSION_STATE_CHANGED = 0x4000;
 
 /***/ }),
 
-/***/ 1700:
+/***/ 3122:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -22142,13 +22142,13 @@ exports.LAST_KEY = exports.TRANSACTION_STATE;
 
 /***/ }),
 
-/***/ 1823:
+/***/ 7729:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const awsCaBundle = __nccwpck_require__(2536);
+const awsCaBundle = __nccwpck_require__(1194);
 
 /**
  * @deprecated
@@ -22161,7 +22161,7 @@ exports["Amazon RDS"] = {
 
 /***/ }),
 
-/***/ 2301:
+/***/ 2899:
 /***/ ((module) => {
 
 "use strict";
@@ -22233,14 +22233,14 @@ module.exports.GEOMETRY = 0xff; // aka GEOMETRY
 
 /***/ }),
 
-/***/ 5655:
+/***/ 2789:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Connection = __nccwpck_require__(3604);
-const ConnectionConfig = __nccwpck_require__(5009);
+const Connection = __nccwpck_require__(250);
+const ConnectionConfig = __nccwpck_require__(1931);
 
 function createConnection(opts) {
   return new Connection({ config: new ConnectionConfig(opts) });
@@ -22251,14 +22251,14 @@ module.exports = createConnection;
 
 /***/ }),
 
-/***/ 9561:
+/***/ 4147:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Pool = __nccwpck_require__(6470);
-const PoolConfig = __nccwpck_require__(6343);
+const Pool = __nccwpck_require__(6336);
+const PoolConfig = __nccwpck_require__(4653);
 
 function createPool(config) {
   return new Pool({ config: new PoolConfig(config) });
@@ -22269,13 +22269,13 @@ module.exports = createPool;
 
 /***/ }),
 
-/***/ 408:
+/***/ 1098:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const PoolCluster = __nccwpck_require__(4767);
+const PoolCluster = __nccwpck_require__(7193);
 
 function createPoolCluster(config) {
   return new PoolCluster(config);
@@ -22286,7 +22286,7 @@ module.exports = createPoolCluster;
 
 /***/ }),
 
-/***/ 5679:
+/***/ 2749:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22319,7 +22319,7 @@ let cardinalRecommended = false;
 try {
   // the purpose of this is to prevent projects using Webpack from displaying a warning during runtime if cardinal is not a dependency
   const REQUIRE_TERMINATOR = '';
-  highlightFn = (__nccwpck_require__(4158).highlight);
+  highlightFn = (__nccwpck_require__(8941).highlight);
 } catch {
   highlightFn = (text) => {
     if (!cardinalRecommended) {
@@ -22377,13 +22377,13 @@ exports.fieldEscape = fieldEscape;
 
 /***/ }),
 
-/***/ 7552:
+/***/ 7062:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 const MAX_PACKET_LENGTH = 16777215;
 
@@ -22580,7 +22580,7 @@ module.exports = PacketParser;
 
 /***/ }),
 
-/***/ 3630:
+/***/ 3924:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22588,7 +22588,7 @@ module.exports = PacketParser;
 
 
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 class AuthNextFactor {
   constructor(opts) {
@@ -22623,7 +22623,7 @@ module.exports = AuthNextFactor;
 
 /***/ }),
 
-/***/ 9361:
+/***/ 1323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22631,7 +22631,7 @@ module.exports = AuthNextFactor;
 
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 class AuthSwitchRequest {
   constructor(opts) {
@@ -22669,7 +22669,7 @@ module.exports = AuthSwitchRequest;
 
 /***/ }),
 
-/***/ 2840:
+/***/ 1666:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22677,7 +22677,7 @@ module.exports = AuthSwitchRequest;
 
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 class AuthSwitchRequestMoreData {
   constructor(data) {
@@ -22710,7 +22710,7 @@ module.exports = AuthSwitchRequestMoreData;
 
 /***/ }),
 
-/***/ 5989:
+/***/ 1359:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22718,7 +22718,7 @@ module.exports = AuthSwitchRequestMoreData;
 
 // http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::AuthSwitchRequest
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 class AuthSwitchResponse {
   constructor(data) {
@@ -22748,14 +22748,14 @@ module.exports = AuthSwitchResponse;
 
 /***/ }),
 
-/***/ 6500:
+/***/ 9698:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Types = __nccwpck_require__(2301);
-const Packet = __nccwpck_require__(2410);
+const Types = __nccwpck_require__(2899);
+const Packet = __nccwpck_require__(3164);
 
 const binaryReader = new Array(256);
 
@@ -22851,7 +22851,7 @@ module.exports = BinaryRow;
 
 /***/ }),
 
-/***/ 2328:
+/***/ 2930:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -22859,8 +22859,8 @@ module.exports = BinaryRow;
 
 // http://dev.mysql.com/doc/internals/en/com-binlog-dump.html#packet-COM_BINLOG_DUMP
 
-const Packet = __nccwpck_require__(2410);
-const CommandCodes = __nccwpck_require__(8648);
+const Packet = __nccwpck_require__(3164);
+const CommandCodes = __nccwpck_require__(1438);
 
 // TODO: add flag to constants
 // 0x01 - BINLOG_DUMP_NON_BLOCK
@@ -22892,7 +22892,7 @@ module.exports = BinlogDump;
 
 /***/ }),
 
-/***/ 7755:
+/***/ 6625:
 /***/ ((module) => {
 
 "use strict";
@@ -23015,17 +23015,17 @@ module.exports = function parseStatusVars(buffer) {
 
 /***/ }),
 
-/***/ 2250:
+/***/ 9896:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const CommandCode = __nccwpck_require__(8648);
-const ClientConstants = __nccwpck_require__(9441);
-const Packet = __nccwpck_require__(2410);
-const auth41 = __nccwpck_require__(3378);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const CommandCode = __nccwpck_require__(1438);
+const ClientConstants = __nccwpck_require__(551);
+const Packet = __nccwpck_require__(3164);
+const auth41 = __nccwpck_require__(1420);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 // https://dev.mysql.com/doc/internals/en/com-change-user.html#packet-COM_CHANGE_USER
 class ChangeUser {
@@ -23120,14 +23120,14 @@ module.exports = ChangeUser;
 
 /***/ }),
 
-/***/ 6618:
+/***/ 6144:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
-const CommandCodes = __nccwpck_require__(8648);
+const Packet = __nccwpck_require__(3164);
+const CommandCodes = __nccwpck_require__(1438);
 
 class CloseStatement {
   constructor(id) {
@@ -23149,15 +23149,15 @@ module.exports = CloseStatement;
 
 /***/ }),
 
-/***/ 1570:
+/***/ 1800:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
-const StringParser = __nccwpck_require__(1936);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const Packet = __nccwpck_require__(3164);
+const StringParser = __nccwpck_require__(8838);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 const fields = ['catalog', 'schema', 'table', 'orgTable', 'name', 'orgName'];
 
@@ -23230,12 +23230,12 @@ class ColumnDefinition {
   }
 
   [Symbol.for('nodejs.util.inspect.custom')](depth, inspectOptions, inspect) {
-    const Types = __nccwpck_require__(2301);
+    const Types = __nccwpck_require__(2899);
     const typeNames = [];
     for (const t in Types) {
       typeNames[Types[t]] = t;
     }
-    const fiedFlags = __nccwpck_require__(4720);
+    const fiedFlags = __nccwpck_require__(2342);
     const flagNames = [];
     // TODO: respect inspectOptions.showHidden
     //const inspectFlags = inspectOptions.showHidden ? this.flags : this.flags & ~fiedFlags.PRI_KEY;
@@ -23448,17 +23448,17 @@ module.exports = ColumnDefinition;
 
 /***/ }),
 
-/***/ 3879:
+/***/ 6337:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const CursorType = __nccwpck_require__(6196);
-const CommandCodes = __nccwpck_require__(8648);
-const Types = __nccwpck_require__(2301);
-const Packet = __nccwpck_require__(2410);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const CursorType = __nccwpck_require__(7990);
+const CommandCodes = __nccwpck_require__(1438);
+const Types = __nccwpck_require__(2899);
+const Packet = __nccwpck_require__(3164);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 function isJSON(value) {
   return (
@@ -23670,14 +23670,14 @@ module.exports = Execute;
 
 /***/ }),
 
-/***/ 6353:
+/***/ 1179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
-const ClientConstants = __nccwpck_require__(9441);
+const Packet = __nccwpck_require__(3164);
+const ClientConstants = __nccwpck_require__(551);
 
 // https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake
 
@@ -23790,17 +23790,17 @@ module.exports = Handshake;
 
 /***/ }),
 
-/***/ 4391:
+/***/ 7501:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const ClientConstants = __nccwpck_require__(9441);
-const CharsetToEncoding = __nccwpck_require__(9713);
-const Packet = __nccwpck_require__(2410);
+const ClientConstants = __nccwpck_require__(551);
+const CharsetToEncoding = __nccwpck_require__(7035);
+const Packet = __nccwpck_require__(3164);
 
-const auth41 = __nccwpck_require__(3378);
+const auth41 = __nccwpck_require__(1420);
 
 class HandshakeResponse {
   constructor(handshake) {
@@ -23942,7 +23942,7 @@ module.exports = HandshakeResponse;
 
 /***/ }),
 
-/***/ 6784:
+/***/ 5906:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -23959,25 +23959,25 @@ module.exports = HandshakeResponse;
 
 const process = __nccwpck_require__(932);
 
-const AuthNextFactor = __nccwpck_require__(3630);
-const AuthSwitchRequest = __nccwpck_require__(9361);
-const AuthSwitchRequestMoreData = __nccwpck_require__(2840);
-const AuthSwitchResponse = __nccwpck_require__(5989);
-const BinaryRow = __nccwpck_require__(6500);
-const BinlogDump = __nccwpck_require__(2328);
-const ChangeUser = __nccwpck_require__(2250);
-const CloseStatement = __nccwpck_require__(6618);
-const ColumnDefinition = __nccwpck_require__(1570);
-const Execute = __nccwpck_require__(3879);
-const Handshake = __nccwpck_require__(6353);
-const HandshakeResponse = __nccwpck_require__(4391);
-const PrepareStatement = __nccwpck_require__(341);
-const PreparedStatementHeader = __nccwpck_require__(4221);
-const Query = __nccwpck_require__(7168);
-const RegisterSlave = __nccwpck_require__(4103);
-const ResultSetHeader = __nccwpck_require__(803);
-const SSLRequest = __nccwpck_require__(6712);
-const TextRow = __nccwpck_require__(9122);
+const AuthNextFactor = __nccwpck_require__(3924);
+const AuthSwitchRequest = __nccwpck_require__(1323);
+const AuthSwitchRequestMoreData = __nccwpck_require__(1666);
+const AuthSwitchResponse = __nccwpck_require__(1359);
+const BinaryRow = __nccwpck_require__(9698);
+const BinlogDump = __nccwpck_require__(2930);
+const ChangeUser = __nccwpck_require__(9896);
+const CloseStatement = __nccwpck_require__(6144);
+const ColumnDefinition = __nccwpck_require__(1800);
+const Execute = __nccwpck_require__(6337);
+const Handshake = __nccwpck_require__(1179);
+const HandshakeResponse = __nccwpck_require__(7501);
+const PrepareStatement = __nccwpck_require__(743);
+const PreparedStatementHeader = __nccwpck_require__(1399);
+const Query = __nccwpck_require__(6290);
+const RegisterSlave = __nccwpck_require__(6037);
+const ResultSetHeader = __nccwpck_require__(4273);
+const SSLRequest = __nccwpck_require__(274);
+const TextRow = __nccwpck_require__(2764);
 
 const ctorMap = {
   AuthNextFactor,
@@ -24016,7 +24016,7 @@ Object.entries(ctorMap).forEach(([name, ctor]) => {
 });
 
 // simple packets:
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 exports.Packet = Packet;
 
 class OK {
@@ -24102,7 +24102,7 @@ exports.Error = Error;
 
 /***/ }),
 
-/***/ 2410:
+/***/ 3164:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24113,11 +24113,11 @@ exports.Error = Error;
 
 
 
-const ErrorCodeToName = __nccwpck_require__(7129);
+const ErrorCodeToName = __nccwpck_require__(2067);
 const NativeBuffer = (__nccwpck_require__(181).Buffer);
-const Long = __nccwpck_require__(5957);
-const StringParser = __nccwpck_require__(1936);
-const Types = __nccwpck_require__(2301);
+const Long = __nccwpck_require__(1519);
+const StringParser = __nccwpck_require__(8838);
+const Types = __nccwpck_require__(2899);
 const INVALID_DATE = new Date(NaN);
 
 // this is nearly duplicate of previous function so generated code is not slower
@@ -25040,16 +25040,16 @@ module.exports = Packet;
 
 /***/ }),
 
-/***/ 341:
+/***/ 743:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
-const CommandCodes = __nccwpck_require__(8648);
-const StringParser = __nccwpck_require__(1936);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const Packet = __nccwpck_require__(3164);
+const CommandCodes = __nccwpck_require__(1438);
+const StringParser = __nccwpck_require__(8838);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 class PrepareStatement {
   constructor(sql, charsetNumber) {
@@ -25075,7 +25075,7 @@ module.exports = PrepareStatement;
 
 /***/ }),
 
-/***/ 4221:
+/***/ 1399:
 /***/ ((module) => {
 
 "use strict";
@@ -25099,16 +25099,16 @@ module.exports = PreparedStatementHeader;
 
 /***/ }),
 
-/***/ 7168:
+/***/ 6290:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
-const CommandCode = __nccwpck_require__(8648);
-const StringParser = __nccwpck_require__(1936);
-const CharsetToEncoding = __nccwpck_require__(9713);
+const Packet = __nccwpck_require__(3164);
+const CommandCode = __nccwpck_require__(1438);
+const StringParser = __nccwpck_require__(8838);
+const CharsetToEncoding = __nccwpck_require__(7035);
 
 class Query {
   constructor(sql, charsetNumber) {
@@ -25134,7 +25134,7 @@ module.exports = Query;
 
 /***/ }),
 
-/***/ 4103:
+/***/ 6037:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25143,8 +25143,8 @@ module.exports = Query;
 // http://dev.mysql.com/doc/internals/en/com-register-slave.html
 // note that documentation is incorrect, for example command code is actually 0x15 but documented as 0x14
 
-const Packet = __nccwpck_require__(2410);
-const CommandCodes = __nccwpck_require__(8648);
+const Packet = __nccwpck_require__(3164);
+const CommandCodes = __nccwpck_require__(1438);
 
 class RegisterSlave {
   constructor(opts) {
@@ -25188,7 +25188,7 @@ module.exports = RegisterSlave;
 
 /***/ }),
 
-/***/ 803:
+/***/ 4273:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -25197,12 +25197,12 @@ module.exports = RegisterSlave;
 // TODO: rename to OK packet
 // https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
 
-const Packet = __nccwpck_require__(2410);
-const ClientConstants = __nccwpck_require__(9441);
-const ServerSatusFlags = __nccwpck_require__(898);
+const Packet = __nccwpck_require__(3164);
+const ClientConstants = __nccwpck_require__(551);
+const ServerSatusFlags = __nccwpck_require__(8496);
 
-const EncodingToCharset = __nccwpck_require__(9112);
-const sessionInfoTypes = __nccwpck_require__(1700);
+const EncodingToCharset = __nccwpck_require__(482);
+const sessionInfoTypes = __nccwpck_require__(3122);
 
 class ResultSetHeader {
   constructor(packet, connection) {
@@ -25320,14 +25320,14 @@ module.exports = ResultSetHeader;
 
 /***/ }),
 
-/***/ 6712:
+/***/ 274:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const ClientConstants = __nccwpck_require__(9441);
-const Packet = __nccwpck_require__(2410);
+const ClientConstants = __nccwpck_require__(551);
+const Packet = __nccwpck_require__(3164);
 
 class SSLRequest {
   constructor(flags, charset) {
@@ -25353,13 +25353,13 @@ module.exports = SSLRequest;
 
 /***/ }),
 
-/***/ 9122:
+/***/ 2764:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Packet = __nccwpck_require__(2410);
+const Packet = __nccwpck_require__(3164);
 
 class TextRow {
   constructor(columns) {
@@ -25408,18 +25408,18 @@ module.exports = TextRow;
 
 /***/ }),
 
-/***/ 2448:
+/***/ 8166:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const FieldFlags = __nccwpck_require__(4720);
-const Charsets = __nccwpck_require__(4399);
-const Types = __nccwpck_require__(2301);
-const helpers = __nccwpck_require__(5679);
-const genFunc = __nccwpck_require__(7263);
-const parserCache = __nccwpck_require__(8979);
+const FieldFlags = __nccwpck_require__(2342);
+const Charsets = __nccwpck_require__(6565);
+const Types = __nccwpck_require__(2899);
+const helpers = __nccwpck_require__(2749);
+const genFunc = __nccwpck_require__(5005);
+const parserCache = __nccwpck_require__(7001);
 const typeNames = [];
 for (const t in Types) {
   typeNames[Types[t]] = t;
@@ -25651,13 +25651,13 @@ module.exports = getBinaryParser;
 
 /***/ }),
 
-/***/ 8979:
+/***/ 7001:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const { createLRU } = __nccwpck_require__(3806);
+const { createLRU } = __nccwpck_require__(4648);
 
 const parserCache = createLRU({
   max: 15000,
@@ -25727,16 +25727,16 @@ module.exports = {
 
 /***/ }),
 
-/***/ 9457:
+/***/ 4687:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const FieldFlags = __nccwpck_require__(4720);
-const Charsets = __nccwpck_require__(4399);
-const Types = __nccwpck_require__(2301);
-const helpers = __nccwpck_require__(5679);
+const FieldFlags = __nccwpck_require__(2342);
+const Charsets = __nccwpck_require__(6565);
+const Types = __nccwpck_require__(2899);
+const helpers = __nccwpck_require__(2749);
 
 const typeNames = [];
 for (const t in Types) {
@@ -25948,15 +25948,15 @@ module.exports = getBinaryParser;
 
 /***/ }),
 
-/***/ 1683:
+/***/ 8581:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Types = __nccwpck_require__(2301);
-const Charsets = __nccwpck_require__(4399);
-const helpers = __nccwpck_require__(5679);
+const Types = __nccwpck_require__(2899);
+const Charsets = __nccwpck_require__(6565);
+const helpers = __nccwpck_require__(2749);
 
 const typeNames = [];
 for (const t in Types) {
@@ -26108,14 +26108,14 @@ module.exports = getTextParser;
 
 /***/ }),
 
-/***/ 1936:
+/***/ 8838:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Iconv = __nccwpck_require__(2211);
-const { createLRU } = __nccwpck_require__(3806);
+const Iconv = __nccwpck_require__(9093);
+const { createLRU } = __nccwpck_require__(4648);
 
 const decoderCache = createLRU({
   max: 500,
@@ -26166,17 +26166,17 @@ exports.encode = function (string, encoding, options) {
 
 /***/ }),
 
-/***/ 5406:
+/***/ 3664:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const Types = __nccwpck_require__(2301);
-const Charsets = __nccwpck_require__(4399);
-const helpers = __nccwpck_require__(5679);
-const genFunc = __nccwpck_require__(7263);
-const parserCache = __nccwpck_require__(8979);
+const Types = __nccwpck_require__(2899);
+const Charsets = __nccwpck_require__(6565);
+const helpers = __nccwpck_require__(2749);
+const genFunc = __nccwpck_require__(5005);
+const parserCache = __nccwpck_require__(7001);
 
 const typeNames = [];
 for (const t in Types) {
@@ -26388,17 +26388,17 @@ module.exports = getTextParser;
 
 /***/ }),
 
-/***/ 6470:
+/***/ 6336:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const BasePool = __nccwpck_require__(4854);
+const BasePool = __nccwpck_require__(5400);
 
 class Pool extends BasePool {
   promise(promiseImpl) {
-    const PromisePool = __nccwpck_require__(4108);
+    const PromisePool = __nccwpck_require__(3558);
     return new PromisePool(this, promiseImpl);
   }
 }
@@ -26408,7 +26408,7 @@ module.exports = Pool;
 
 /***/ }),
 
-/***/ 4767:
+/***/ 7193:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -26416,9 +26416,9 @@ module.exports = Pool;
 
 const process = __nccwpck_require__(932);
 
-const Pool = __nccwpck_require__(6470);
-const PoolConfig = __nccwpck_require__(6343);
-const Connection = __nccwpck_require__(3604);
+const Pool = __nccwpck_require__(6336);
+const PoolConfig = __nccwpck_require__(4653);
+const Connection = __nccwpck_require__(250);
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
 
 /**
@@ -26785,13 +26785,13 @@ module.exports = PoolCluster;
 
 /***/ }),
 
-/***/ 6343:
+/***/ 4653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const ConnectionConfig = __nccwpck_require__(5009);
+const ConnectionConfig = __nccwpck_require__(1931);
 
 class PoolConfig {
   constructor(options) {
@@ -26823,17 +26823,17 @@ module.exports = PoolConfig;
 
 /***/ }),
 
-/***/ 757:
+/***/ 7323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const BasePoolConnection = __nccwpck_require__(4053);
+const BasePoolConnection = __nccwpck_require__(4963);
 
 class PoolConnection extends BasePoolConnection {
   promise(promiseImpl) {
-    const PromisePoolConnection = __nccwpck_require__(2703);
+    const PromisePoolConnection = __nccwpck_require__(4981);
     return new PromisePoolConnection(this, promiseImpl);
   }
 }
@@ -26843,17 +26843,17 @@ module.exports = PoolConnection;
 
 /***/ }),
 
-/***/ 3974:
+/***/ 2628:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
-const PromisePreparedStatementInfo = __nccwpck_require__(8720);
-const makeDoneCb = __nccwpck_require__(1979);
-const inheritEvents = __nccwpck_require__(3479);
-const BaseConnection = __nccwpck_require__(2308);
+const PromisePreparedStatementInfo = __nccwpck_require__(602);
+const makeDoneCb = __nccwpck_require__(6297);
+const inheritEvents = __nccwpck_require__(3025);
+const BaseConnection = __nccwpck_require__(4786);
 
 class PromiseConnection extends EventEmitter {
   constructor(connection, promiseImpl) {
@@ -27073,7 +27073,7 @@ module.exports = PromiseConnection;
 
 /***/ }),
 
-/***/ 3479:
+/***/ 3025:
 /***/ ((module) => {
 
 "use strict";
@@ -27108,7 +27108,7 @@ module.exports = inheritEvents;
 
 /***/ }),
 
-/***/ 1979:
+/***/ 6297:
 /***/ ((module) => {
 
 "use strict";
@@ -27135,17 +27135,17 @@ module.exports = makeDoneCb;
 
 /***/ }),
 
-/***/ 4108:
+/***/ 3558:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
-const makeDoneCb = __nccwpck_require__(1979);
-const PromisePoolConnection = __nccwpck_require__(2703);
-const inheritEvents = __nccwpck_require__(3479);
-const BasePool = __nccwpck_require__(4854);
+const makeDoneCb = __nccwpck_require__(6297);
+const PromisePoolConnection = __nccwpck_require__(4981);
+const inheritEvents = __nccwpck_require__(3025);
+const BasePool = __nccwpck_require__(5400);
 
 class PromisePool extends EventEmitter {
   constructor(pool, thePromise) {
@@ -27255,14 +27255,14 @@ module.exports = PromisePool;
 
 /***/ }),
 
-/***/ 8605:
+/***/ 1391:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const PromisePoolConnection = __nccwpck_require__(2703);
-const makeDoneCb = __nccwpck_require__(1979);
+const PromisePoolConnection = __nccwpck_require__(4981);
+const makeDoneCb = __nccwpck_require__(6297);
 
 class PromisePoolNamespace {
   constructor(poolNamespace, thePromise) {
@@ -27317,14 +27317,14 @@ module.exports = PromisePoolNamespace;
 
 /***/ }),
 
-/***/ 2703:
+/***/ 4981:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const PromiseConnection = __nccwpck_require__(3974);
-const BasePoolConnection = __nccwpck_require__(4053);
+const PromiseConnection = __nccwpck_require__(2628);
+const BasePoolConnection = __nccwpck_require__(4963);
 
 class PromisePoolConnection extends PromiseConnection {
   constructor(connection, promiseImpl) {
@@ -27344,13 +27344,13 @@ module.exports = PromisePoolConnection;
 
 /***/ }),
 
-/***/ 8720:
+/***/ 602:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const makeDoneCb = __nccwpck_require__(1979);
+const makeDoneCb = __nccwpck_require__(6297);
 
 class PromisePreparedStatementInfo {
   constructor(statement, promiseImpl) {
@@ -27384,25 +27384,25 @@ module.exports = PromisePreparedStatementInfo;
 
 /***/ }),
 
-/***/ 2599:
+/***/ 2281:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-const SqlString = __nccwpck_require__(3255);
+const SqlString = __nccwpck_require__(9301);
 const EventEmitter = (__nccwpck_require__(4434).EventEmitter);
-const parserCache = __nccwpck_require__(8979);
-const PoolCluster = __nccwpck_require__(4767);
-const createConnection = __nccwpck_require__(5655);
-const createPool = __nccwpck_require__(9561);
-const createPoolCluster = __nccwpck_require__(408);
-const PromiseConnection = __nccwpck_require__(3974);
-const PromisePool = __nccwpck_require__(4108);
-const makeDoneCb = __nccwpck_require__(1979);
-const PromisePoolConnection = __nccwpck_require__(2703);
-const inheritEvents = __nccwpck_require__(3479);
-const PromisePoolNamespace = __nccwpck_require__(8605);
+const parserCache = __nccwpck_require__(7001);
+const PoolCluster = __nccwpck_require__(7193);
+const createConnection = __nccwpck_require__(2789);
+const createPool = __nccwpck_require__(4147);
+const createPoolCluster = __nccwpck_require__(1098);
+const PromiseConnection = __nccwpck_require__(2628);
+const PromisePool = __nccwpck_require__(3558);
+const makeDoneCb = __nccwpck_require__(6297);
+const PromisePoolConnection = __nccwpck_require__(4981);
+const inheritEvents = __nccwpck_require__(3025);
+const PromisePoolNamespace = __nccwpck_require__(1391);
 
 function createConnectionPromise(opts) {
   const coreConnection = createConnection(opts);
@@ -27573,14 +27573,14 @@ exports.PromisePool = PromisePool;
 exports.PromiseConnection = PromiseConnection;
 exports.PromisePoolConnection = PromisePoolConnection;
 
-exports.__defineGetter__('Types', () => __nccwpck_require__(2301));
+exports.__defineGetter__('Types', () => __nccwpck_require__(2899));
 
 exports.__defineGetter__('Charsets', () =>
-  __nccwpck_require__(4399)
+  __nccwpck_require__(6565)
 );
 
 exports.__defineGetter__('CharsetToEncoding', () =>
-  __nccwpck_require__(9713)
+  __nccwpck_require__(7035)
 );
 
 exports.setMaxParserCache = function (max) {
@@ -27594,7 +27594,7 @@ exports.clearParserCache = function () {
 
 /***/ }),
 
-/***/ 3267:
+/***/ 2966:
 /***/ ((module) => {
 
 "use strict";
@@ -27602,7 +27602,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["8740","䏰䰲䘃䖦䕸𧉧䵷䖳�
 
 /***/ }),
 
-/***/ 4488:
+/***/ 3719:
 /***/ ((module) => {
 
 "use strict";
@@ -27610,7 +27610,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["0","\\u0000",127,"€"],["8140","�
 
 /***/ }),
 
-/***/ 1166:
+/***/ 1525:
 /***/ ((module) => {
 
 "use strict";
@@ -27618,7 +27618,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["0","\\u0000",127],["8141","갂갃�
 
 /***/ }),
 
-/***/ 2324:
+/***/ 4567:
 /***/ ((module) => {
 
 "use strict";
@@ -27626,7 +27626,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["0","\\u0000",127],["a140","　，�
 
 /***/ }),
 
-/***/ 6406:
+/***/ 3789:
 /***/ ((module) => {
 
 "use strict";
@@ -27634,7 +27634,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["0","\\u0000",127],["8ea1","｡",62]
 
 /***/ }),
 
-/***/ 9129:
+/***/ 700:
 /***/ ((module) => {
 
 "use strict";
@@ -27642,7 +27642,7 @@ module.exports = /*#__PURE__*/JSON.parse('{"uChars":[128,165,169,178,184,216,226
 
 /***/ }),
 
-/***/ 5914:
+/***/ 1981:
 /***/ ((module) => {
 
 "use strict";
@@ -27650,7 +27650,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["a140","",62],["a180","",32],[
 
 /***/ }),
 
-/***/ 679:
+/***/ 5446:
 /***/ ((module) => {
 
 "use strict";
@@ -27658,7 +27658,7 @@ module.exports = /*#__PURE__*/JSON.parse('[["0","\\u0000",128],["a1","｡",62],[
 
 /***/ }),
 
-/***/ 7466:
+/***/ 9231:
 /***/ ((module) => {
 
 "use strict";
@@ -27706,8 +27706,8 @@ module.exports = /*#__PURE__*/JSON.parse('{"name":"mysql2","version":"3.17.4","d
 /************************************************************************/
 var __webpack_exports__ = {};
 
-const yaml = __nccwpck_require__(5080);
-const mysql = __nccwpck_require__(2599);
+const yaml = __nccwpck_require__(150);
+const mysql = __nccwpck_require__(2281);
 
 const PKGBASE_REGEX = /^[a-zA-Z0-9_\/.+-]+$/;
 const STATUS_MAP = {
@@ -27777,11 +27777,21 @@ async function main() {
 
     for (const pkgbase of pkgbases) {
       try {
+        // First check if record exists (mirrors old trigger.py: Status.objects.get)
+        const [existing] = await connection.execute(
+          'SELECT `key` FROM cactus_status WHERE `key` = ?',
+          [pkgbase]
+        );
+        if (existing.length === 0) {
+          console.error(`❌ ${pkgbase}: not found in database`);
+          failed.push(pkgbase);
+          continue;
+        }
+
         const [r1] = await connection.execute(
-          `INSERT INTO cactus_status (\`key\`, status, detail, workflow, timestamp)
-           VALUES (?, ?, ?, ?, NOW())
-           ON DUPLICATE KEY UPDATE status = VALUES(status), detail = VALUES(detail), workflow = VALUES(workflow), timestamp = NOW()`,
-          [pkgbase, dbStatus, detailValue, workflow]
+          `UPDATE cactus_status SET status = ?, detail = ?, workflow = ?, timestamp = NOW()
+           WHERE \`key\` = ?`,
+          [dbStatus, detailValue, workflow, pkgbase]
         );
         console.log(`✅ ${pkgbase} → ${dbStatus}`);
         success.push(pkgbase);

--- a/actions/update-status-js/index.js
+++ b/actions/update-status-js/index.js
@@ -72,11 +72,15 @@ async function main() {
     for (const pkgbase of pkgbases) {
       try {
         const [r1] = await connection.execute(
-          `INSERT INTO cactus_status (\`key\`, status, detail, workflow, timestamp)
-           VALUES (?, ?, ?, ?, NOW())
-           ON DUPLICATE KEY UPDATE status = VALUES(status), detail = VALUES(detail), workflow = VALUES(workflow), timestamp = NOW()`,
-          [pkgbase, dbStatus, detailValue, workflow]
+          `UPDATE cactus_status SET status = ?, detail = ?, workflow = ?, timestamp = NOW()
+           WHERE \`key\` = ?`,
+          [dbStatus, detailValue, workflow, pkgbase]
         );
+        if (r1.affectedRows === 0) {
+          console.error(`❌ ${pkgbase}: not found in database`);
+          failed.push(pkgbase);
+          continue;
+        }
         console.log(`✅ ${pkgbase} → ${dbStatus}`);
         success.push(pkgbase);
       } catch (err) {


### PR DESCRIPTION
## Bug
- Symptom: `python-pytensor` stuck in STALE status for 8h, scheduler never scheduled it
- Root cause: `update-status-js/index.js` used `INSERT ... ON DUPLICATE KEY UPDATE` which silently creates STALE records for pkgbase entries that don't exist in the database or don't have a corresponding cactus.yaml. The scheduler sees these phantom STALE entries but can't resolve them since there's no cactus.yaml to build.

## Fix
- Replace `INSERT ... ON DUPLICATE KEY UPDATE` with `UPDATE` + `affectedRows === 0` check
- Non-existent records are reported as failures instead of being silently inserted
- Avoids race condition of separate SELECT before UPDATE
- Mirrors old `trigger.py` behavior (`Status.objects.get` throws on missing records)

## Verification
- Behavior now matches old `python -m cactus.detector.trigger` which only operated on existing database records
- dist/index.js rebuilt with ncc